### PR TITLE
Implement turn counter

### DIFF
--- a/Main.gd
+++ b/Main.gd
@@ -1,16 +1,61 @@
-# class member variables go here, for example:
-# var a = 2
-# var b = "textvar"
+extends Node2D
+# This file contains the main game logic
+
+# ---------------- #
+# Public variables #
+# ---------------- #
+
+# The current turn
+export(int) var turn = 1
+
+# Duration of one turn, in seconds
+export(float) var turn_duration = 10.0
+
+# Fired when a turn is being processed.
+# The only argument is the time difference from the previous frame
+signal process_turn
+
+# ----------------------- #
+# Implementation details  #
+# Don't modify outside of #
+# this file!              #
+# ----------------------- #
+
+# Whether a turn is currently being executed
+var _executing_turn = false
+# If the turn is being executed, how far into the turn, in seconds
+var _sim_time = 0.0
+
+onready var _end_turn_button = get_node("end_turn_button")
+onready var _player_ship = get_node("player_ship")
+
+# ----------------------- #
 
 func _ready():
 	set_process_input(true)
-	pass
+	set_fixed_process(true)
+	set_turn(turn)
 
 func _input(ev):
 	# Mouse in viewport coordinates
-	if (ev.type==InputEvent.MOUSE_BUTTON):
-		
-		# print("Mouse Click/Unclick at: ", ev.pos)
-		get_node("player_ship").set_target(ev.pos)
+	if ev.type == InputEvent.MOUSE_BUTTON and not _executing_turn:
+		_player_ship.set_target(ev.pos)
 		get_node("move_target_indicator").set_pos(ev.pos)
 
+func _fixed_process(delta):
+	if _executing_turn:
+		_sim_time += delta
+		get_tree().call_group(0, "entities", "_process_turn", delta)
+		if _sim_time > turn_duration:
+			_executing_turn = false
+			_sim_time = 0
+			_end_turn_button.set_disabled(false)
+			set_turn(turn + 1)
+
+func set_turn(new_turn):
+	turn = new_turn
+	get_node("turn_label").text = "Turn: " + str(turn)
+
+func end_turn():
+	_end_turn_button.set_disabled(true)
+	_executing_turn = true

--- a/Main.gd
+++ b/Main.gd
@@ -11,10 +11,6 @@ export(int) var turn = 1
 # Duration of one turn, in seconds
 export(float) var turn_duration = 10.0
 
-# Fired when a turn is being processed.
-# The only argument is the time difference from the previous frame
-signal process_turn
-
 # ----------------------- #
 # Implementation details  #
 # Don't modify outside of #
@@ -25,6 +21,7 @@ signal process_turn
 var _executing_turn = false
 # If the turn is being executed, how far into the turn, in seconds
 var _sim_time = 0.0
+# Total time in the game
 var _elapsed_time = 0.0
 
 onready var _end_turn_button = get_node("end_turn_button")
@@ -49,6 +46,8 @@ func _fixed_process(delta):
 		_sim_time += delta
 		_elapsed_time += delta
 		get_tree().call_group(0, "entities", "_process_turn", delta)
+		
+		# If the turn is over
 		if _sim_time > turn_duration:
 			_executing_turn = false
 			_sim_time = 0

--- a/Main.gd
+++ b/Main.gd
@@ -25,6 +25,7 @@ signal process_turn
 var _executing_turn = false
 # If the turn is being executed, how far into the turn, in seconds
 var _sim_time = 0.0
+var _elapsed_time = 0.0
 
 onready var _end_turn_button = get_node("end_turn_button")
 onready var _player_ship = get_node("player_ship")
@@ -43,8 +44,10 @@ func _unhandled_input(ev):
 		get_node("move_target_indicator").set_pos(ev.pos)
 
 func _fixed_process(delta):
+	get_node("elapsed_time_label").set_text("Elapsed time: %.2fs" % _elapsed_time)
 	if _executing_turn:
 		_sim_time += delta
+		_elapsed_time += delta
 		get_tree().call_group(0, "entities", "_process_turn", delta)
 		if _sim_time > turn_duration:
 			_executing_turn = false
@@ -54,7 +57,7 @@ func _fixed_process(delta):
 
 func set_turn(new_turn):
 	turn = new_turn
-	get_node("turn_label").text = "Turn: " + str(turn)
+	get_node("turn_label").set_text("Turn: " + str(turn))
 
 func end_turn():
 	_end_turn_button.set_disabled(true)

--- a/Main.gd
+++ b/Main.gd
@@ -32,11 +32,11 @@ onready var _player_ship = get_node("player_ship")
 # ----------------------- #
 
 func _ready():
-	set_process_input(true)
+	set_process_unhandled_input(true)
 	set_fixed_process(true)
 	set_turn(turn)
 
-func _input(ev):
+func _unhandled_input(ev):
 	# Mouse in viewport coordinates
 	if ev.type == InputEvent.MOUSE_BUTTON and not _executing_turn:
 		_player_ship.set_target(ev.pos)

--- a/player/Player.gd
+++ b/player/Player.gd
@@ -12,9 +12,8 @@ var target = Vector2(get_pos())
 func _ready():
 	set_fixed_process(true)
 	set_rot(initial_rot)
-	pass
 
-func _fixed_process(delta):
+func _process_turn(delta):
 	var angle_to_target = target.angle_to_point(get_pos())
 	if get_pos() == target:
 		pass

--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -13,8 +13,27 @@ extents = Vector2( 3.70631, 10.1802 )
 [node name="Main" type="Node2D"]
 
 script/script = ExtResource( 1 )
+turn = 1
+turn_duration = 10.0
 
-[node name="player_ship" type="KinematicBody2D" parent="."]
+[node name="turn_label" type="Label" parent="."]
+
+focus/ignore_mouse = true
+focus/stop_mouse = true
+size_flags/horizontal = 2
+size_flags/vertical = 0
+margin/left = 5.0
+margin/top = 5.0
+margin/right = 45.0
+margin/bottom = 19.0
+text = "Turn:"
+percent_visible = 1.0
+lines_skipped = 0
+max_lines_visible = -1
+
+[node name="player_ship" type="KinematicBody2D" parent="." groups=[
+"entities",
+]]
 
 transform/pos = Vector2( 340.629, 204.269 )
 input/pickable = false
@@ -45,6 +64,7 @@ _update_shape_index = 0
 
 [node name="move_target_indicator" type="Node2D" parent="."]
 
+editor/display_folded = true
 visibility/visible = false
 script/script = ExtResource( 4 )
 player = NodePath("../player_ship")
@@ -62,5 +82,23 @@ texture/scale = Vector2( 1, 1 )
 texture/rotation = 0.0
 invert/enable = false
 invert/border = 100.0
+
+[node name="end_turn_button" type="Button" parent="."]
+
+focus/ignore_mouse = false
+focus/stop_mouse = true
+size_flags/horizontal = 2
+size_flags/vertical = 2
+margin/left = 8.0
+margin/top = 23.0
+margin/right = 75.0
+margin/bottom = 43.0
+toggle_mode = false
+enabled_focus_mode = 2
+shortcut = null
+text = "End Turn"
+flat = false
+
+[connection signal="pressed" from="end_turn_button" to="." method="end_turn"]
 
 

--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -99,6 +99,25 @@ shortcut = null
 text = "End Turn"
 flat = false
 
+[node name="elapsed_time_label" type="Label" parent="."]
+
+anchor/left = 3
+anchor/top = 3
+anchor/right = 3
+anchor/bottom = 3
+focus/ignore_mouse = true
+focus/stop_mouse = true
+size_flags/horizontal = 2
+size_flags/vertical = 0
+margin/left = -266.0
+margin/top = 24.0
+margin/right = -485.0
+margin/bottom = 10.0
+text = "Elapsed time:"
+percent_visible = 1.0
+lines_skipped = 0
+max_lines_visible = -1
+
 [connection signal="pressed" from="end_turn_button" to="." method="end_turn"]
 
 


### PR DESCRIPTION
This implements the "turn" system of the game, which currently separates actions by 10-second intervals. In the future, the gameplay will consist of players making decisions that will be simultaneously executed when all players end their turn.

Changes in this PR include:

* In the top left corner of the screen, text that shows the current turn and a button that ends the turn.
* In the top middle of the screen, text that shows the total time simulated.
* Instead of implementing `fixed_process` in each entity to be simulated, one should now implement `_process_turn` and then add the entity to the `entities` group. Only the nodes in the `entities` group will be simulated.