### PR TITLE
Improve movement line preview algorithm

### DIFF
--- a/entity/Entity.gd
+++ b/entity/Entity.gd
@@ -47,8 +47,8 @@ func _process_turn(delta):
 
 func move_forward(delta):
 	if self.position.distance_squared_to(target) > pow(speed * delta, 2):
-		var default = Vector2(1, 0).rotated(self.rotation)
-		var veloc = default * speed * delta
+		#TODO: Refactor to dedicated utility/physics class
+		var veloc = Vector2(speed * delta, 0).rotated(self.rotation)
 		self.position += veloc
 
 		# Collision logic, but still needs work

--- a/player/MoveTargetIndicator.gd
+++ b/player/MoveTargetIndicator.gd
@@ -85,9 +85,14 @@ func recalculate_move_approx_line(color):
 		if previous_point == next_point or draw_time > max_draw_time:
 			drawing = false
 		elif rot == angle_to_target:
-			# Interpolate to keep approximation limits consistent
-			var to_end = next_point.linear_interpolate(_player.target, (max_draw_time - draw_time) / max_draw_time)
-			move_approx_cache.append(to_end)
+			var rem_time = max_draw_time - draw_time
+			var endpoint = _player.target
+			var dist_squared = next_point.distance_squared_to(_player.target)
+			var max_dist_squared = pow(_player.speed * rem_time, 2)
+			# Ensure line is within approximation limits
+			if dist_squared > max_dist_squared:
+				endpoint = next_point.linear_interpolate(_player.target, sqrt(max_dist_squared / dist_squared))
+			move_approx_cache.append(endpoint)
 			drawing = false
 		else:
 			draw_time += line_draw_rate

--- a/player/MoveTargetIndicator.gd
+++ b/player/MoveTargetIndicator.gd
@@ -37,6 +37,11 @@ func _draw():
 		draw_move_approx_line(color)
 
 func draw_move_approx_line(color):
+#	if move_approx_cache.size() > 1:
+#		var points = PoolVector2Array(move_approx_cache)
+#		for i in range(0, move_approx_cache.size() - 1):
+#			points.set(i, points[i] - self.position)
+#		self.draw_polyline(points, color, 1.0, true)
 	var previous = Vector2(_player.position)
 	for next in move_approx_cache:
 		draw_line(previous - self.position, next - self.position, color)
@@ -45,23 +50,24 @@ func draw_move_approx_line(color):
 func recalculate_move_approx_line(color):
 	move_approx_cache.clear()
 	var previous_point = Vector2(_player.position)
-	var next_point = Vector2(_player.position)
 	var rot = _player.rotation
 	var max_rot = _player.max_rot * line_draw_rate
 	var draw_time = 0
 	var drawing = true
+	move_approx_cache.append(_player.position)
 	while drawing:
 		var angle_to_target = _player.target.angle_to_point(previous_point)
 		var current_rot = _player.angle_conv(rot)
 		var target_rot = _player.angle_conv(angle_to_target)
 		var angle_diff = target_rot - current_rot
+		var next_point = previous_point
 		if previous_point.distance_squared_to(_player.target) > pow(_player.speed * line_draw_rate, 2):
 			#TODO: Refactor to dedicated utility/physics class
 			var default = Vector2(1, 0).rotated(rot)
 			var veloc = default * _player.speed * line_draw_rate
-			previous_point += veloc
+			next_point += veloc
 		else:
-			previous_point = _player.target
+			next_point = _player.target
 		if abs(angle_diff) < max_rot:
 			rot = angle_to_target
 		elif (angle_diff > 0 && angle_diff < PI) || (angle_diff > -2 * PI && angle_diff < -PI):
@@ -73,5 +79,5 @@ func recalculate_move_approx_line(color):
 			drawing = false
 		else:
 			draw_time += line_draw_rate
-			move_approx_cache.append(next_point)
-		next_point = previous_point
+		move_approx_cache.append(next_point)
+		previous_point = next_point

--- a/player/MoveTargetIndicator.gd
+++ b/player/MoveTargetIndicator.gd
@@ -48,12 +48,14 @@ func draw_move_approx_line(color):
 		previous = next
 
 func recalculate_move_approx_line(color):
-	move_approx_cache.clear()
-	var previous_point = Vector2(_player.position)
-	var rot = _player.rotation
 	var max_rot = _player.max_rot * line_draw_rate
+	var speed_diff = _player.speed * line_draw_rate
+
+	var rot = _player.rotation
+	var previous_point = Vector2(_player.position)
 	var draw_time = 0
 	var drawing = true
+	move_approx_cache.clear()
 	move_approx_cache.append(_player.position)
 	while drawing:
 		var angle_to_target = _player.target.angle_to_point(previous_point)
@@ -61,10 +63,9 @@ func recalculate_move_approx_line(color):
 		var target_rot = _player.angle_conv(angle_to_target)
 		var angle_diff = target_rot - current_rot
 		var next_point = previous_point
-		if previous_point.distance_squared_to(_player.target) > pow(_player.speed * line_draw_rate, 2):
+		if previous_point.distance_squared_to(_player.target) > pow(speed_diff, 2):
 			#TODO: Refactor to dedicated utility/physics class
-			var default = Vector2(1, 0).rotated(rot)
-			var veloc = default * _player.speed * line_draw_rate
+			var veloc = Vector2(speed_diff, 0).rotated(rot)
 			next_point += veloc
 		else:
 			next_point = _player.target

--- a/player/MoveTargetIndicator.gd
+++ b/player/MoveTargetIndicator.gd
@@ -3,16 +3,21 @@ extends Node2D
 export(NodePath) var player
 
 var _player
-var average_delta = 0.015
-var time_out = 0
-var max_tick_till_time_out = 10000
-var guide_list = []
+
+# Rate at which to approximate movement line, in seconds
+var line_draw_rate = 0.1
+
+# Maximum amount of time to draw movement approx line, in seconds
+var max_draw_time = 10.0
+
+# Cache of points in the movement approx line
+var move_approx_cache = []
 
 
 func _ready():
 	_player = get_node(player)
 	self.position = self._player.position
-	set_process(true)
+	self.set_process(true)
 
 func _process(delta):
 	if _player.position == _player.target:
@@ -20,55 +25,53 @@ func _process(delta):
 	else:
 		self.show()
 		var color = get_node("indicator_shape").get_color()
-		draw_guide_line(color)
-		update()
+		recalculate_move_approx_line(color)
+		# Note: "update" as in "schedule a draw call"
+		self.update()
 
 func _draw():
 	if _player.position != _player.target:
 		var color = get_node("indicator_shape").get_color()
 		# Note: these coordinates are relative to this node
 		# draw_line(_player.position - self.position, Vector2(0, 0), color)
-		draw_all(color)
+		draw_move_approx_line(color)
 
-func draw_all(color):
-	var move_point1 = Vector2(_player.position)
-	for point in guide_list:
-		draw_line(move_point1-self.position, point-self.position, color)
-		move_point1 = point
+func draw_move_approx_line(color):
+	var previous = Vector2(_player.position)
+	for next in move_approx_cache:
+		draw_line(previous - self.position, next - self.position, color)
+		previous = next
 
-func draw_guide_line(color):
-	# var max_rot = _player.max_rot
-	guide_list = []
-	average_delta = 0.1
-	var move_point1 = Vector2(_player.position)
-	var move_point2 = Vector2(_player.position)
+func recalculate_move_approx_line(color):
+	move_approx_cache.clear()
+	var previous_point = Vector2(_player.position)
+	var next_point = Vector2(_player.position)
 	var rot = _player.rotation
-	var ticks_to_target = move_point1.distance_to(_player.target) / (_player.speed * average_delta)
-	var max_rot = _player.max_rot * average_delta
-	while(1):
-		move_point2 = move_point1
-		var angle_to_target = _player.target.angle_to_point(move_point1)
+	var max_rot = _player.max_rot * line_draw_rate
+	var draw_time = 0
+	var drawing = true
+	while drawing:
+		var angle_to_target = _player.target.angle_to_point(previous_point)
 		var current_rot = _player.angle_conv(rot)
 		var target_rot = _player.angle_conv(angle_to_target)
-		var diff = target_rot - current_rot
-		if move_point1.distance_squared_to(_player.target) > pow(_player.speed * average_delta, 2):
+		var angle_diff = target_rot - current_rot
+		if previous_point.distance_squared_to(_player.target) > pow(_player.speed * line_draw_rate, 2):
+			#TODO: Refactor to dedicated utility/physics class
 			var default = Vector2(1, 0).rotated(rot)
-			var veloc = default * _player.speed * average_delta
-			move_point1 += veloc
+			var veloc = default * _player.speed * line_draw_rate
+			previous_point += veloc
 		else:
-			move_point1 = (_player.target)
-		if abs(diff) < max_rot:
-			rot = (angle_to_target)
-		elif (diff > 0 && diff < PI) || (diff > -2 * PI && diff < -PI):
-			rot = (rot + max_rot)
+			previous_point = _player.target
+		if abs(angle_diff) < max_rot:
+			rot = angle_to_target
+		elif (angle_diff > 0 && angle_diff < PI) || (angle_diff > -2 * PI && angle_diff < -PI):
+			rot = rot + max_rot
 		else:
-			rot = (rot - max_rot)
-
-		if move_point1 == move_point2 || time_out > max_tick_till_time_out:
-			time_out = 0
-			break
-
-		time_out += 1
-		guide_list.append(move_point2)
-		#draw_line(move_point2 - self.position, move_point1 - self.position, color)
-
+			rot = rot - max_rot
+		
+		if previous_point == next_point or draw_time > max_draw_time:
+			drawing = false
+		else:
+			draw_time += line_draw_rate
+			move_approx_cache.append(next_point)
+		next_point = previous_point

--- a/player/MoveTargetIndicator.gd
+++ b/player/MoveTargetIndicator.gd
@@ -13,6 +13,9 @@ var max_draw_time = 10.0
 # Cache of points in the movement approx line
 var move_approx_cache = []
 
+# For performance, keep track of previous positions of player and target
+var previous_endpoints = null
+
 
 func _ready():
 	_player = get_node(player)
@@ -23,11 +26,13 @@ func _process(delta):
 	if _player.position == _player.target:
 		self.hide()
 	else:
+		if previous_endpoints != [_player.position, _player.target]:
+			var color = get_node("indicator_shape").get_color()
+			recalculate_move_approx_line(color)
+			previous_endpoints = [_player.position, _player.target]
+			# Note: "update" as in "schedule a draw call"
+			self.update()
 		self.show()
-		var color = get_node("indicator_shape").get_color()
-		recalculate_move_approx_line(color)
-		# Note: "update" as in "schedule a draw call"
-		self.update()
 
 func _draw():
 	if _player.position != _player.target:

--- a/player/MoveTargetIndicator.gd
+++ b/player/MoveTargetIndicator.gd
@@ -81,9 +81,14 @@ func recalculate_move_approx_line(color):
 		else:
 			rot = rot - max_rot
 		
+		move_approx_cache.append(next_point)
 		if previous_point == next_point or draw_time > max_draw_time:
+			drawing = false
+		elif rot == angle_to_target:
+			# Interpolate to keep approximation limits consistent
+			var to_end = next_point.linear_interpolate(_player.target, (max_draw_time - draw_time) / max_draw_time)
+			move_approx_cache.append(to_end)
 			drawing = false
 		else:
 			draw_time += line_draw_rate
-		move_approx_cache.append(next_point)
 		previous_point = next_point


### PR DESCRIPTION
Ok, starting to optimize the movement line algorithm. I've refactored the names so the algorithm is easier to read, and I've made the draw times more sensible (e.g. using actual units of time instead of an arbitrary max time of "10000").

Changes:
* Only add endpoints when traveling in a straight line
* Constant optimizations
* Recalculate line only when target or position change